### PR TITLE
chore(commit-message-check.yml): Create commit-message-check.yml

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,0 +1,28 @@
+name: Commit Message Format Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate-commit-messages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Validate commit messages
+        run: |
+          echo "⏳ Commit messages are being checked..."
+          COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:"%s")
+          echo "$COMMITS" | while read COMMIT_MSG; do
+            echo "🔍 $COMMIT_MSG"
+            echo "$COMMIT_MSG" | grep -Eq "^(feat|fix|chore|docs|style|refactor|test)(\(.+\))?: .{1,}" || {
+              echo "❌ Incorrect commit message:"
+              echo "$COMMIT_MSG"
+              echo "🧠 Correct format: <type>(<scope>): <message>"
+              exit 1
+            }
+          done


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce a standardized commit message format for pull requests targeting the `main` branch.

### Workflow addition:
* [`.github/workflows/commit-message-check.yml`](diffhunk://#diff-73e8619abf322bb25f592ba9554da3f8d577c5f9031cca8909560c3413d81a29R1-R28): Added a new workflow named "Commit Message Format Check" that validates commit messages against a predefined format using a regular expression. The allowed types are `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, and `test`. Commit messages must follow the format `<type>(<scope>): <message>`.